### PR TITLE
feat(README): Add link to in-depth tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ To test this action locally, you can run the following in your hugo site:
 ```shell
 TARGET_REPO=benmatselby/benmatselby.github.io ../hugo-deploy-gh-pages/action.sh
 ```
+
+## Tutorial
+For an in depth tutorial, see [this blog post](https://www.jameswright.xyz/post/deploy-hugo-academic-using-githubio/). It is geared mostly at users of the Hugo Academic theme, but should be more broadly applicable.

--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ TARGET_REPO=benmatselby/benmatselby.github.io ../hugo-deploy-gh-pages/action.sh
 ```
 
 ## Tutorial
+
 For an in depth tutorial, see [this blog post](https://www.jameswright.xyz/post/deploy-hugo-academic-using-githubio/). It is geared mostly at users of the Hugo Academic theme, but should be more broadly applicable.


### PR DESCRIPTION
I wrote an article detailing the process of setting up the automatic deployment of a Hugo site using this Action. Thought it might be nice to link here, but I understand if you don't want to link to someone else's tutorial.
