### PR TITLE
Allow using *extended* version of hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This GitHub action will build your [Hugo site](https://gohugo.io/), and then pub
 - `GITHUB_ACTOR`: The name of the person or app that initiated the workflow. For example, octocat. [See here](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables).
 - `TARGET_REPO`: This is the repo slug for the GitHub pages site. e.g. `benmatselby/benmatselby.github.io`.
 - `HUGO_VERSION`: This allows you to control which version of Hugo you want to use. There is a default within the action, but this may be out of date.
+- `HUGO_EXTENDED`: If set to `true`, the *extended* version of Hugo will be used.
 - `HUGO_ARGS`: Arguments passed to `hugo`.
 - `CNAME`: Contents of a `CNAME` file.
 

--- a/action.sh
+++ b/action.sh
@@ -22,8 +22,16 @@ if [[ -z "${HUGO_VERSION}" ]]; then
     echo "No HUGO_VERSION was set, so defaulting to ${HUGO_VERSION}"
 fi
 
-echo "Downloading Hugo: ${HUGO_VERSION}"
-curl -sSL https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz > /tmp/hugo.tar.gz && tar -f /tmp/hugo.tar.gz -xz
+if [[ "${HUGO_EXTENDED}" = "true" ]]; then
+  EXTENDED_INFO=" (extended)"
+  EXTENDED_URL="_extended"
+else
+  EXTENDED_INFO=""
+  EXTENDED_URL=""
+fi
+
+echo "Downloading Hugo: ${HUGO_VERSION}${EXTENDED_INFO}"
+curl -sSL https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}${EXTENDED_URL}_Linux-64bit.tar.gz > /tmp/hugo.tar.gz && tar -f /tmp/hugo.tar.gz -xz
 
 echo "Building the Hugo site with: ./hugo ${HUGO_ARGS}"
 ./hugo "${HUGO_ARGS}"

--- a/action.sh
+++ b/action.sh
@@ -24,14 +24,14 @@ fi
 
 if [[ "${HUGO_EXTENDED}" = "true" ]]; then
   EXTENDED_INFO=" (extended)"
-  EXTENDED_URL="_extended"
+  EXTENDED_URL="extended_"
 else
   EXTENDED_INFO=""
   EXTENDED_URL=""
 fi
 
 echo "Downloading Hugo: ${HUGO_VERSION}${EXTENDED_INFO}"
-curl -sSL https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}${EXTENDED_URL}_Linux-64bit.tar.gz > /tmp/hugo.tar.gz && tar -f /tmp/hugo.tar.gz -xz
+curl -sSL https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${EXTENDED_URL}${HUGO_VERSION}_Linux-64bit.tar.gz > /tmp/hugo.tar.gz && tar -f /tmp/hugo.tar.gz -xz
 
 echo "Building the Hugo site with: ./hugo ${HUGO_ARGS}"
 ./hugo "${HUGO_ARGS}"

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   hugo_version:
     description: "The version of hugo to use."
     required: true
+  hugo_extended:
+    description: "If set to `true`, use the *extended* version of hugo."
+    required: false
   github_token:
     description: "Your PAT to authorise the action to do things."
     required: true


### PR DESCRIPTION
This allows to specify an environment variable `HUGO_EXTENDED`. If set to `true`, it will download the *extended* version of Hugo (fixes #27).