### PR TITLE
fix: Add golang to docker image installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
 	ca-certificates  \
 	curl \
 	jq \
+	golang \
 	git && \
 	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- Add `golang` to the docker image installation

Resolves #38 