### PR TITLE
All users to optionally install Go into the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.13.0
+
+- All users to optionally install Go within the action environment. This is not required to deploy the Hugo site.
+
 ## 1.12.0
 
 - Always pull the latest Hugo release, if there is not one set.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 FROM debian:buster-slim
 LABEL maintainer="Ben Selby <benmatselby@gmail.com>"
 
+##
+# Define the location of Go.
+# We may not always install it, but if we do, it's here.
+##
+ENV GOPATH /go
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+
+##
+# Installation of all the tooling we need.
+##
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends \
 	ca-certificates  \
@@ -9,6 +19,12 @@ RUN apt-get update && \
 	git && \
 	rm -rf /var/lib/apt/lists/*
 
+##
+# Copy over the action script.
+##
 COPY action.sh /usr/bin/action.sh
 
+##
+# Run the action.
+##
 ENTRYPOINT ["action.sh"]

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ This GitHub action will build your [Hugo site](https://gohugo.io/), and then pub
 
 ## Environment Variables
 
-- `GITHUB_ACTOR`: The name of the person or app that initiated the workflow. For example, octocat. [See here](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables).
-- `TARGET_REPO`: This is the repo slug for the GitHub pages site. e.g. `benmatselby/benmatselby.github.io`.
-- `TARGET_BRANCH`: This is the branch to push the public files e.g. `docs`. Default is `master` branch.
-- `HUGO_VERSION`: This allows you to control which version of Hugo you want to use. The default is to pull the latest version.
-- `HUGO_EXTENDED`: If set to `true`, the _extended_ version of Hugo will be used. Default is `false`.
-- `HUGO_ARGS`: Arguments passed to `hugo`.
 - `CNAME`: Contents of a `CNAME` file.
+- `GITHUB_ACTOR`: The name of the person or app that initiated the workflow. For example, octocat. [See here](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables).
+- `GO_VERSION`: The version of Go you may want to install. This is not required for basic operation. Values should be in the format of `1.17`.
+- `HUGO_ARGS`: Arguments passed to `hugo`.
+- `HUGO_EXTENDED`: If set to `true`, the _extended_ version of Hugo will be used. Default is `false`.
+- `HUGO_VERSION`: This allows you to control which version of Hugo you want to use. The default is to pull the latest version.
+- `TARGET_BRANCH`: This is the branch to push the public files e.g. `docs`. Default is `master` branch.
+- `TARGET_REPO`: This is the repo slug for the GitHub pages site. e.g. `benmatselby/benmatselby.github.io`.
 
 ## Example
 

--- a/action.sh
+++ b/action.sh
@@ -3,6 +3,9 @@
 set -e
 set -o pipefail
 
+###
+# Environment variable definitions.
+##
 if [[ -n "${TOKEN}" ]]; then
     GITHUB_TOKEN=${TOKEN}
 fi
@@ -35,11 +38,42 @@ else
   EXTENDED_URL=""
 fi
 
+###
+# Downloading of Hugo.
+###
 echo "Downloading Hugo: ${HUGO_VERSION}${EXTENDED_INFO}"
 URL=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${EXTENDED_URL}${HUGO_VERSION}_Linux-64bit.deb
 echo "Using '${URL}' to download Hugo"
 curl -sSL "${URL}" > /tmp/hugo.deb && dpkg --force architecture -i /tmp/hugo.deb
 
+
+###
+# Optionally install Go.
+###
+# shellcheck disable=SC2153
+if [[ -n "${GO_VERSION}" ]]; then
+  echo "Installing Go: ${GO_VERSION}"
+
+  curl -sL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" > /tmp/go.tar.gz
+  tar -C /tmp -xf /tmp/go.tar.gz
+  mv /tmp/go /go
+  rm -rf \
+    /usr/local/go/pkg/*/cmd \
+    /usr/local/go/pkg/bootstrap \
+    /usr/local/go/pkg/obj \
+    /usr/local/go/pkg/tool/*/api \
+    /usr/local/go/pkg/tool/*/go_bootstrap \
+    /usr/local/go/src/cmd/dist/dist \
+    /tmp/go.tag.gz
+
+  # Provide version details and sanity check installation
+  echo "Installed Go: ${GO_VERSION}"
+  go version
+fi
+
+###
+# Build the site.
+###
 echo "Building the Hugo site with: 'hugo ${HUGO_ARGS}'"
 hugo "${HUGO_ARGS}"
 
@@ -68,7 +102,9 @@ fi
 echo "Getting hash for base repository commit"
 HASH=$(echo "${GITHUB_SHA}" | cut -c1-7)
 
+###
 # Now add all the changes and commit and push
+###
 if [[ "${TARGET_BRANCH}" != "master" ]]; then
   git checkout -b ${TARGET_BRANCH}
 fi

--- a/action.yml
+++ b/action.yml
@@ -8,24 +8,24 @@ branding:
   icon: "target"
   color: "purple"
 inputs:
-  hugo_version:
-    description: "The version of hugo to use."
-    required: true
-  hugo_extended:
-    description: "If set to `true`, use the *extended* version of hugo."
+  cname:
+    description: "If you are defining a custom domain name for your GitHub site, put that value in this variable."
     required: false
   github_token:
     description: "Your PAT to authorise the action to do things."
     required: true
-  target_repo:
-    description: "The repo name you want to clone and push to."
+  hugo_args:
+    description: "Any extra arguments to pass to Hugo."
+    required: false
+  hugo_extended:
+    description: "If set to `true`, use the *extended* version of hugo."
+    required: false
+  hugo_version:
+    description: "The version of hugo to use."
     required: true
   target_branch:
     description: "The branch to push the hugo public files, default will be master branch."
     required: false
-  hugo_args:
-    description: "Any extra arguments to pass to Hugo."
-    required: false
-  cname:
-    description: "If you are defining a custom domain name for your GitHub site, put that value in this variable."
-    required: false
+  target_repo:
+    description: "The repo name you want to clone and push to."
+    required: true

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   github_token:
     description: "Your PAT to authorise the action to do things."
     required: true
+  go_version:
+    description: "The version of Go to install. Go won't be installed if this isn't set."
+    required: false
   hugo_args:
     description: "Any extra arguments to pass to Hugo."
     required: false


### PR DESCRIPTION
This is by no means required for the action to work.

Some folks on #38 have said they require Go for certain Hugo themes. This PR allows folks to install any version of Go they require, and it will be available inside the container.

If no `GO_VERSION` environment variable is set in the action definition, Go will not be installed by default, as it is not required.

Testing:

Build the image.

```shell
hugo-deploy-gh-pages on  go-version [!⇡] took 26s
at 18:50:53 ❯ docker build --pull --rm -f "Dockerfile" -t hugodeployghpages:latest .
[+] Building 13.6s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                                                                        0.0s
 => => transferring dockerfile: 585B                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                           0.0s
 => => transferring context: 34B                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/debian:buster-slim                                                                       1.3s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                               0.0s
 => CACHED [1/3] FROM docker.io/library/debian:buster-slim@sha256:f6e5cbc7eaaa232ae1db675d83eabfffdabeb9054515c15c2fb510da6bc618a7          0.0s
 => [internal] load build context                                                                                                           0.1s
 => => transferring context: 31B                                                                                                            0.1s
 => [2/3] RUN apt-get update &&  apt-get install -y --no-install-recommends  ca-certificates   curl  jq  git &&  rm -rf /var/lib/apt/list  11.6s
 => [3/3] COPY action.sh /usr/bin/action.sh                                                                                                 0.0s
 => exporting to image                                                                                                                      0.5s
 => => exporting layers                                                                                                                     0.5s
 => => writing image sha256:6b49b27703c23ea075c1ddcb0ff097749554f40fa1a03c17771e172c446b48cf                                                0.0s
 => => naming to docker.io/library/hugodeployghpages:latest                                                                                 0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```

Run the action:

```shell
hugo-deploy-gh-pages on  go-version [!⇡]
at 18:51:14 ❯ docker run --rm \
  -eGITHUB_TOKEN \
  -eGO_VERSION=1.17 \
  -eTARGET_REPO=benmatselby/benmatselby.github.io \
  -v "$(pwd)":/site/ \
  --workdir /site \
  hugodeployghpages
No TARGET_BRANCH was set, so defaulting to master
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 43851    0 43851    0     0   127k      0 --:--:-- --:--:-- --:--:--  127k
No HUGO_VERSION was set, so defaulting to 0.92.1
Downloading Hugo: 0.92.1
Using 'https://github.com/gohugoio/hugo/releases/download/v0.92.1/hugo_0.92.1_Linux-64bit.deb' to download Hugo
Selecting previously unselected package hugo.
(Reading database ... 9843 files and directories currently installed.)
Preparing to unpack /tmp/hugo.deb ...
Unpacking hugo (0.92.1) ...
Setting up hugo (0.92.1) ...
Installing Go: 1.17
Installed Go: 1.17
go version go1.17 linux/amd64
```
