### PR TITLE
Mark current directory as safe

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -77,6 +77,9 @@ if [[ -n "${GO_VERSION}" ]]; then
   go version
 fi
 
+# https://github.com/actions/checkout/issues/766
+git config --global --add safe.directory "${PWD}"
+
 ###
 # Build the site.
 ###


### PR DESCRIPTION
to work-around the following:
`ERROR Failed to read Git log: fatal: detected dubious ownership in repository at '/github/workspace'`

actions/runner#2033 describes the problem and actions/checkout#766 suggests to run
`git config --global --add safe.directory "$GITHUB_WORKSPACE"` inside the container action script.

The `$GITHUB_WORKFLOW` is, however, valid in the environment that runs our action in a container, but in the container it's the working directory, hence the `$PWD`.
For example in a workflow in my 'status' repo, the `$GITHUB_WORKSPACE` is `/home/runner/work/status/status` and the action is run in a container like this:
`docker run --workdir /github/workspace -v "/home/runner/work/status/status":"/github/workspace"`
i.e. `$GITHUB_WORKSPACE` (`/home/runner/work/status/status`) is mounted into `/github/workspace` in the container and the directory is set as working directory (`$PWD` inside the action script).

Fixes #49