### PR TITLE
Update base image to use Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 LABEL maintainer="Ben Selby <benmatselby@gmail.com>"
 
 ##


### PR DESCRIPTION
The named Debian image in the `Dockerfile` references an out-of-date version, which causes the action to fail:

```
The repository 'http://deb.debian.org/debian buster Release' does not have a Release file
```

The current stable version is Bookworm so I updated to that and the build works.