### PR TITLE
Mark the current directory as "git safe"

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -83,6 +83,8 @@ fi
 ###
 git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf 'https://github.com/'
 
+# https://github.com/actions/checkout/issues/766
+git config --global --add safe.directory "${PWD}"
 
 ###
 # Build the site.


### PR DESCRIPTION
Hugo can run read-only git operations when building the site, therefore the current working directory needs to be marked as git-safe *before* Hugo is run.

For details see #49 and #50

---

v2.4.0 fixed one issue with the build of https://github.com/packit/status.git and this issue popped up.